### PR TITLE
Patch out requirement on 'lalsuite'

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -10,9 +10,10 @@ export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
 
 
-endgroup "Start Docker"
+( endgroup "Start Docker" ) 2> /dev/null
 
-startgroup "Configuring conda"
+( startgroup "Configuring conda" ) 2> /dev/null
+
 export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
@@ -36,34 +37,38 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-endgroup "Configuring conda"
+
+( endgroup "Configuring conda" ) 2> /dev/null
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    startgroup "Running conda debug"
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
     fi
     conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-    endgroup "Running conda debug"
+
     # Drop into an interactive shell
     /bin/bash
 else
-    startgroup "Running conda $BUILD_CMD"
     conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-    endgroup "Running conda build"
-    startgroup "Validating outputs"
+    ( startgroup "Validating outputs" ) 2> /dev/null
+
     validate_recipe_outputs "${FEEDSTOCK_NAME}"
-    endgroup "Validating outputs"
+
+    ( endgroup "Validating outputs" ) 2> /dev/null
+
+    ( startgroup "Uploading packages" ) 2> /dev/null
 
     if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-        startgroup "Uploading packages"
         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
-        endgroup "Uploading packages"
     fi
+
+    ( endgroup "Uploading packages" ) 2> /dev/null
 fi
+
+( startgroup "Final checks" ) 2> /dev/null
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -13,18 +13,23 @@ function startgroup {
         travis )
             echo "$1"
             echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        github_actions )
+            echo "::group::$1";;
         * )
             echo "$1";;
     esac
-}
+} 2> /dev/null
 
 function endgroup {
     # End a foldable group of log lines
     # Pass a single argument, quoted
+
     case ${CI:-} in
         azure )
             echo "##[endgroup]";;
         travis )
             echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+        github_actions )
+            echo "::endgroup::";;
     esac
-}
+} 2> /dev/null

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -7,7 +7,7 @@
 
 source .scripts/logging_utils.sh
 
-startgroup "Configure Docker"
+( startgroup "Configure Docker" ) 2> /dev/null
 
 set -xeo pipefail
 
@@ -52,11 +52,11 @@ if [ -z "${DOCKER_IMAGE}" ]; then
         echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
         DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
         if [ "${DOCKER_IMAGE}" = "" ]; then
-            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
-            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+            echo "No docker_image entry found in ${CONFIG}. Falling back to quay.io/condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="quay.io/condaforge/linux-anvil-comp7"
         fi
     else
-        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
+        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 quay.io/condaforge/linux-anvil-comp7 )"
     fi
 fi
 
@@ -69,9 +69,11 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
-endgroup "Configure Docker"
 
-startgroup "Start Docker"
+( endgroup "Configure Docker" ) 2> /dev/null
+
+( startgroup "Start Docker" ) 2> /dev/null
+
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
@@ -95,3 +97,6 @@ docker run ${DOCKER_RUN_ARGS} \
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"
+
+# This closes the last group opened in `build_steps.sh`
+( endgroup "Final checks" ) 2> /dev/null

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/cwinpy-feedstoc
 
 Summary: CW Inference in Python
 
-Development: https://github.com/cwinpy/cwinpy/
+Development: https://github.com/cwinpy/cwinpy.git
 
-Documentation: https://cwinpy.readthedocs.io/en/latest/
+Documentation: https://cwinpy.readthedocs.io/
 
-A Python module for performing Bayesian inference for continuous gravitational-wave signals from pulsars.
+A Python module for performing Bayesian inference for
+continuous gravitational-wave signals from pulsars.
 
 
 Current build status
@@ -43,6 +44,7 @@ Installing `cwinpy` from the `conda-forge` channel can be achieved by adding `co
 
 ```
 conda config --add channels conda-forge
+conda config --set channel_priority strict
 ```
 
 Once the `conda-forge` channel has been enabled, `cwinpy` can be installed with:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,8 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 23e4947f2e405578b772a980ad232bec95e4c503f03579508a7b09b3637cdd0e
   patches:
+    # unpin numpy
+    - requirements-unpin-numpy.patch
     # we handle lalsuite packages individually
     - requirements-no-lalsuite.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,13 +8,16 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 23e4947f2e405578b772a980ad232bec95e4c503f03579508a7b09b3637cdd0e
+  patches:
+    # we handle lalsuite packages individually
+    - requirements-no-lalsuite.patch
 
 build:
   entry_points:
     - cwinpy_pe = cwinpy.pe.pe:pe_cli
     - cwinpy_pe_dag = cwinpy.pe.pe:pe_dag_cli
     - cwinpy_pe_generate_pp_plots = cwinpy.pe.testing:generate_pp_plots
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,9 +19,9 @@ build:
     - cwinpy_pe = cwinpy.pe.pe:pe_cli
     - cwinpy_pe_dag = cwinpy.pe.pe:pe_dag_cli
     - cwinpy_pe_generate_pp_plots = cwinpy.pe.testing:generate_pp_plots
-  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  number: 1
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
@@ -35,7 +35,6 @@ requirements:
     - configargparse
     - gwosc
     - gwpy
-    - lalframe
     - lintegrate
     - matplotlib-base
     - numba
@@ -43,30 +42,38 @@ requirements:
     - pycondor
     - python >=3.6
     - python-lal >=7.0.0
+    - python-lalframe >=1.5.1
     - python-lalpulsar >=2.0.0
     - scipy
 
 test:
-  imports:
-    - cwinpy
   requires:
+    - lalapps
     - pip
+    - pytest
+    - pytest-socket
+  source_files:
+    - test/
   commands:
+    # check requirements
+    - python -m pip check
+    # run unit tests
+    - python -m pytest test/ -ra -v
+    # check entry points
     - cwinpy_pe --help
     - cwinpy_pe_dag --help
     - cwinpy_pe_generate_pp_plots --help
-    - python -m pip check
 
 about:
   home: https://github.com/cwinpy/cwinpy/
+  doc_url: https://cwinpy.readthedocs.io/
+  dev_url: https://github.com/cwinpy/cwinpy.git
   license: MIT
-  license_family: MIT
   license_file: LICENSE
   summary: CW Inference in Python
-  doc_url: https://cwinpy.readthedocs.io/en/latest/
-  dev_url: https://github.com/cwinpy/cwinpy/
   description: |
-    A Python module for performing Bayesian inference for continuous gravitational-wave signals from pulsars.
+    A Python module for performing Bayesian inference for
+    continuous gravitational-wave signals from pulsars.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,17 +42,20 @@ requirements:
     - numpy >=1.15
     - pycondor
     - python >=3.6
-    - python-lal
-    - python-lalpulsar
+    - python-lal >=7.0.0
+    - python-lalpulsar >=2.0.0
     - scipy
 
 test:
   imports:
     - cwinpy
+  requires:
+    - pip
   commands:
     - cwinpy_pe --help
     - cwinpy_pe_dag --help
     - cwinpy_pe_generate_pp_plots --help
+    - python -m pip check
 
 about:
   home: https://github.com/cwinpy/cwinpy/

--- a/recipe/requirements-no-lalsuite.patch
+++ b/recipe/requirements-no-lalsuite.patch
@@ -1,0 +1,12 @@
+diff --git a/requirements.txt b/requirements.txt
+index a7b5f2c..e6a722e 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -5,7 +5,6 @@ bilby_pipe>=1.0.2
+ matplotlib
+ scipy
+ lintegrate>=0.1.7
+-lalsuite>=6.76
+ numba
+ gwpy>=2.0.0
+ gwosc>=0.5.4

--- a/recipe/requirements-unpin-numpy.patch
+++ b/recipe/requirements-unpin-numpy.patch
@@ -1,0 +1,11 @@
+diff --git a/requirements.txt b/requirements.txt
+index a7b5f2c..5e60862 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,5 +1,5 @@
+ astropy
+-numpy<1.20
++numpy
+ bilby>=1.0.2
+ bilby_pipe>=1.0.2
+ matplotlib


### PR DESCRIPTION
This PR adds a patch to remove the `lalsuite` requirement from the python metadata, since we handle the lalsuite subpackages individually. I also include some random pedantic recipe updates for good measure.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
