### PR TITLE
Patch out test/ directory being installed as a package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,15 @@ source:
   patches:
     # we handle lalsuite packages individually
     - requirements-no-lalsuite.patch
+    # exclude test directory as a package
+    - packages.patch
 
 build:
   entry_points:
     - cwinpy_pe = cwinpy.pe.pe:pe_cli
     - cwinpy_pe_dag = cwinpy.pe.pe:pe_dag_cli
     - cwinpy_pe_generate_pp_plots = cwinpy.pe.testing:generate_pp_plots
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
   # requirements aren't available for Windows
   skip: true  # [win]

--- a/recipe/packages.patch
+++ b/recipe/packages.patch
@@ -1,0 +1,15 @@
+diff --git a/setup.cfg b/setup.cfg
+index c394450..7969f83 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -48,6 +48,10 @@ install_requires =
+ include_package_data = True
+ packages = find:
+ 
++[options.packages.find]
++exclude =
++    test
++
+ [options.package_data]
+ cwinpy =
+     data/S5/hw_inj/*.par


### PR DESCRIPTION
This PR patches the setup.cfg in cwinpy to not install `test/` as its own package. This would be resovled upstream by something like cwinpy/cwinpy#5.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
