### PR TITLE
Add arby as runtime requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
     - cwinpy_pe = cwinpy.pe.pe:pe_cli
     - cwinpy_pe_pipeline = cwinpy.pe.pe:pe_pipeline_cli
     - cwinpy_pe_generate_pp_plots = cwinpy.pe.testing:generate_pp_plots
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   # requirements aren't available for Windows
   skip: true  # [win]
@@ -40,6 +40,7 @@ requirements:
     - setuptools_scm
   run:
     - appdirs
+    - arby
     - astropy
     - bilby >=2.0.1
     - configargparse

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,6 +75,7 @@ test:
     - pytest >=4.6
     - pytest-socket
     - seaborn
+    - tempo2 <2023.5  # [not arm64]
   commands:
     # check requirements
     - python -m pip check  # [not arm64]


### PR DESCRIPTION
This PR adds `arby` as a runtime requirement, see https://git.ligo.org/computing/sccb/-/issues/1238#note_762677 (LIGO.ORG auth required).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
