### PR TITLE
Update build to patch marking failing tests with xfail

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,13 +31,15 @@ source:
     - patches/0001-Remove-lalsuite-Python-requirement.patch
     # patch test to survive no internet connection
     - patches/0002-Handle-no-internet-connection-in-test.patch
+    # patch tests that require libstempo
+    - patches/0003-Add-pytest.mark.xfail-to-tempo2-tests.patch
 
 build:
   entry_points:
     - cwinpy_pe = cwinpy.pe.pe:pe_cli
     - cwinpy_pe_pipeline = cwinpy.pe.pe:pe_pipeline_cli
     - cwinpy_pe_generate_pp_plots = cwinpy.pe.testing:generate_pp_plots
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   # requirements aren't available for Windows, aarch64 or python>3.12
   skip: true  # [win or aarch64 or ppc64le or py>=313]

--- a/recipe/patches/0003-Add-pytest.mark.xfail-to-tempo2-tests.patch
+++ b/recipe/patches/0003-Add-pytest.mark.xfail-to-tempo2-tests.patch
@@ -1,0 +1,36 @@
+From feab8ac298906508c41e01b738cf261bb733c306 Mon Sep 17 00:00:00 2001
+From: Matthew Pitkin <matthew.pitkin@ligo.org>
+Date: Mon, 1 Dec 2025 20:59:07 +0000
+Subject: [PATCH] test_signal.py: add pytest.mark.xfail to tempo2 tests
+
+---
+ cwinpy/test/test_signal.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/cwinpy/test/test_signal.py b/cwinpy/test/test_signal.py
+index b012dca..d9312e2 100644
+--- a/cwinpy/test/test_signal.py
++++ b/cwinpy/test/test_signal.py
+@@ -346,6 +346,9 @@ class TestPhaseOnly:
+         assert maxdfpole < 0.2 * dfmax
+         assert maxdfpole < maxdfplane
+ 
++    @pytest.mark.xfail(
++        raises=(ValueError, UnicodeDecodeError), reason="libstempo issue"
++    )
+     def test_tempo2(self):
+         """
+         Test the phase only when calculated with Tempo2 vs LAL.
+@@ -520,6 +523,9 @@ phi0 = {phi0}
+         shutil.rmtree(cls.fakepardir)
+         shutil.rmtree(cls.fakedatadir)
+ 
++    @pytest.mark.xfail(
++        raises=(ValueError, UnicodeDecodeError), reason="libstempo issue"
++    )
+     def test_ref_freq_heterodyne(self):
+         segments = [
+             (self.fakedatastart, self.fakedatastart + self.fakedataduration),
+-- 
+2.43.0
+


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Some tests that use Tempo2 sometimes fail due to an underlying libstempo issue (https://github.com/vallis/libstempo/issues/49). This update adds a patch to mark those tests with [`@pytest.mark.xfail`](https://docs.pytest.org/en/stable/how-to/skipping.html#xfail-mark-test-functions-as-expected-to-fail) so that the whole test suite does not fail if they do not work.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
